### PR TITLE
Fix typo in Theo's name

### DIFF
--- a/components/Sections/Team.tsx
+++ b/components/Sections/Team.tsx
@@ -93,7 +93,7 @@ const Team: React.FC = () => {
           image={Claire}
         />
         <Person
-          name="Theo Bleir"
+          name="Theo Bleier"
           role="Advisor"
           pronouns="he/him"
           image={Theo}


### PR DESCRIPTION
Currently, it says "Theo Bleir" but I think it's supposed to be "Theo Bleier" https://tmb.sh